### PR TITLE
CORE 1574 - Render checkout according the root parent

### DIFF
--- a/dist/javascripts/zype_wp.js
+++ b/dist/javascripts/zype_wp.js
@@ -56,7 +56,7 @@ function ZypeWP(env) {
 
     };
 
-    this.zypeAuthMarkupRequest = function(zype_auth_type, zype_auth_plan_id, zype_auth_email, zype_auth_paytype, zype_auth_token) {
+    this.zypeAuthMarkupRequest = function(zype_auth_type, zype_auth_plan_id, zype_root_parent, zype_auth_email, zype_auth_paytype, zype_auth_token) {
         jQuery.ajax({
             url: this.env.ajax_endpoint,
             type: 'get',
@@ -64,10 +64,14 @@ function ZypeWP(env) {
                 action: 'zype_auth_markup',
                 type: zype_auth_type,
                 planid: zype_auth_plan_id ? zype_auth_plan_id : '0',
+                rootParent: zype_root_parent
             },
             success: function(response) {
                 try {
-                    jQuery('.content-wrap').replaceWith(response);
+                    id = '';
+                    id = zype_root_parent ? '#' + zype_root_parent + ' ' : '';
+                    id += '.content-wrap'
+                    jQuery(id).replaceWith(response);
                     self.initZypeAjaxForms();
                     self.initZypeAjaxMarkup();
                 } catch (e) {
@@ -212,7 +216,8 @@ function ZypeWP(env) {
 
                         self.zypeAuthMarkupRequest(
                             jQuery(this).data('type'),
-                            jQuery(this).data('planid')
+                            jQuery(this).data('planid'),
+                            jQuery(this).data('root-parent'),
                         );
                     });
                 }

--- a/resources/controllers/Consumer/Subscriptions.php
+++ b/resources/controllers/Consumer/Subscriptions.php
@@ -35,7 +35,7 @@ class Subscriptions extends Base
         exit();
     }
 
-    public function plansView()
+    public function plansView($rootParent)
     {
         global $plans;
         $stripe_pk = Config::get('zype.stripe_pk');
@@ -54,7 +54,8 @@ class Subscriptions extends Base
             'plans' => $plans,
             'title' => $this->title,
             'options' => $this->options,
-            'stripe_pk' => $stripe_pk
+            'stripe_pk' => $stripe_pk,
+            'root_parent' => $rootParent
         ]);
 
         return $content;

--- a/resources/lib/Zype/Api.php
+++ b/resources/lib/Zype/Api.php
@@ -266,7 +266,7 @@ class Api {
         return 'no';
     }
 
-    private static function request($method, $endpoint, $query, $is_auth = false, $cache = true) {
+    private static function request($method, $endpoint, $query, $is_auth = false, $cache = false) {
 
         if ($is_auth) {
             $client = self::$authClient;

--- a/resources/models/Player.php
+++ b/resources/models/Player.php
@@ -16,6 +16,7 @@ class Player {
             'auth_required' => isset($params['auth']) ? $params['auth'] : false,
             'auto_play' => false,
             'audio_only' => isset($params['audio_only']) ? $params['audio_only'] : false,
+            'root_parent' => $params['root_parent']
         ]);
     }
 

--- a/resources/providers/HooksService.php
+++ b/resources/providers/HooksService.php
@@ -101,7 +101,9 @@ class HooksService extends ServiceProvider {
 
     public function zype_auth_markup() {
         if (\Input::get('type')) {
-            echo do_shortcode('[zype_auth type="' . \Input::get('type') . "\" plan_id=\"" . \Input::get('planid') . '"]');
+            echo do_shortcode(
+                '[zype_auth type="' . \Input::get('type') . "\" plan_id=\"" . \Input::get('planid') . "\" root_parent=\"" . \Input::get('rootParent') . '"]'
+            );
         }
         exit;
     }

--- a/resources/shortcodes.php
+++ b/resources/shortcodes.php
@@ -31,6 +31,7 @@ add_shortcode('zype_categories', function() {
 
 add_shortcode('zype_auth', function($attrs = array()) {
     $type = !empty($attrs['type'])? $attrs['type']: Input::get('zype_auth_type', 'login');
+    $rootParent = $attrs['root_parent'];
 
     $loginController = new Consumer\Auth();
     $profileController = new Consumer\Profile();
@@ -44,7 +45,7 @@ add_shortcode('zype_auth', function($attrs = array()) {
         case 'forgot':
             return $profileController->forgot_password();
         case 'plans':
-            return $subscriptionsController->plansView();
+            return $subscriptionsController->plansView($rootParent);
         case 'checkout':
             return $subscriptionsController->checkoutView(Input::get('planid'));
     }

--- a/resources/views/auth/plans.php
+++ b/resources/views/auth/plans.php
@@ -18,18 +18,15 @@
                     </div>
                     <div class="zype-title-plan"><?php echo $plan->name; ?></div>
                   </div>
-                  
+
                   <div class="zype-column-plan">
                     <div class="zype-price-holder">$<?php echo $plan->amount; ?>/<?php if($plan->interval_count >1){echo $plan->interval_count.' '; }?><?php echo substr($plan->interval, 0, 2);  ?><?php if($plan->interval_count >1){echo 's'; }?></div>
-                    <a href="<?php echo get_permalink() . "?zype_auth_type=checkout&planid=" . esc_attr($plan->_id) ?>" class="zype_auth_markup zype-btn-price-plan" data-type="checkout" data-planid="<?php echo esc_attr($plan->_id) ?>">
+                    <a href="<?php echo get_permalink() . "?zype_auth_type=checkout&planid=" . esc_attr($plan->_id) ?>" class="zype_auth_markup zype-btn-price-plan" data-type="checkout" data-planid="<?php echo esc_attr($plan->_id) ?>" data-root-parent="<?php echo $root_parent; ?>">
                         <div class="zype-btn-container-plan">Continue</div>
                     </a>
                   </div>
                 </div>
-                <a href="<?php echo get_permalink() . "?zype_auth_type=checkout&planid=" . esc_attr($plan->_id) ?>" class="zype_auth_markup zype-btn-price-plan-mob" data-type="checkout" data-planid="<?php echo esc_attr($plan->_id) ?>">
-                  <div class="zype-btn-container-plan-mob">Continue</div>
-                </a>
-              <?php } ?> 
+              <?php } ?>
               </div>
             </div>
           </form>

--- a/resources/views/partial/player_embed.php
+++ b/resources/views/partial/player_embed.php
@@ -46,7 +46,7 @@ $video_url  = Themosis\Facades\Config::get('zype.playerHost') . '/embed/' . $vid
                     <div class="overlay_player">
                         <div class="overlay-buttons">
                             <div class="overlay-title">Unlock to watch</div>
-                            <div class="white-button zype-signin-button zype_auth_markup" data-type="plans">Let's go</div>
+                            <div class="white-button zype-signin-button zype_auth_markup" data-type="plans" data-root-parent="<?php echo $root_parent; ?>">Let's go</div>
                         </div>
                     </div>
                 <?php else: ?>
@@ -73,8 +73,15 @@ $video_url  = Themosis\Facades\Config::get('zype.playerHost') . '/embed/' . $vid
                     <?php echo do_shortcode('[zype_signup]');?>
                     <?php echo do_shortcode('[zype_forgot]');?>
                 <?php else: ?>
-                    <?php echo do_shortcode('[zype_auth type="plans"]');?>
-                <?php endif ?>
+                    <?php
+                        $shortCode = '[zype_auth type="plans"';
+                        if($root_parent) {
+                            $shortCode .= ' root_parent="' . $root_parent;
+                        }
+                        $shortCode .= '"]';
+                    ?>
+                    <?php echo do_shortcode($shortCode);?>
+                <?php endif; ?>
             </div>
         </div>
     </div>

--- a/resources/views/video_single.php
+++ b/resources/views/video_single.php
@@ -14,7 +14,7 @@
     }
   }
 ?>
-<div class="zype_video">
+<div class="zype_video" id='zype-video'>
   <div class="zype_video__wrapper">
     <div class="zype_video__heading">
       <h1><?php echo $video->title; ?></h1>
@@ -27,9 +27,9 @@
       </div> -->
     </div>
     <?php if (zype_audio_only()): ?>
-        <?php zype_player_embed($video, ['auth' => $video->subscription_required, 'auto_play' => false, 'audio_only' => true]); ?>
+        <?php zype_player_embed($video, ['auth' => $video->subscription_required, 'auto_play' => false, 'audio_only' => true, 'root_parent' => 'zype-video']); ?>
     <?php else: ?>
-        <?php zype_player_embed($video, ['auth' => $video->subscription_required, 'auto_play' => false, 'audio_only' => false]); ?>
+        <?php zype_player_embed($video, ['auth' => $video->subscription_required, 'auto_play' => false, 'audio_only' => false, 'root_parent' => 'zype-video']); ?>
     <?php endif ?>
   </div>
   <?php if ($view == 'full'): ?>


### PR DESCRIPTION
Render the checkout form and plans into the correct div parent. Previously it was rendering within every class with `.content-wrap`.

The issue appears when having more than one shortcode, i.e.:
```
[zype_auth]

[zype_playlist id='5a74ecaeef995e118e0001e6']
```

JIRA: https://zypeinc.atlassian.net/browse/CORE-1574