### PR TITLE
CORE 3133 - Use custom CSS for carousel arrows instead of fontawesome styles

### DIFF
--- a/dist/javascripts/slick/slick.css
+++ b/dist/javascripts/slick/slick.css
@@ -111,4 +111,6 @@
     display: none;
 }
 
-
+.slider-list .slick-arrow {
+    width: auto
+}


### PR DESCRIPTION
[JIRA](https://zypeinc.atlassian.net/browse/CORE-3133)